### PR TITLE
Expression mapping with variable declaration context

### DIFF
--- a/src/tink/macro/tools/ExprTools.hx
+++ b/src/tink/macro/tools/ExprTools.hx
@@ -177,8 +177,9 @@ class ExprTools {
 				var newCatches = [];
 				for (c in catches)
 				{
-					ctx.push({ name:c.name, expr: null, type:c.type });
-					newCatches.push({name:c.name, expr:c.expr.rec(ctx.copy()), type:c.type});
+					var innerCtx = ctx.copy();
+					innerCtx.push({ name:c.name, expr: null, type:c.type });
+					newCatches.push({name:c.name, expr:c.expr.rec(innerCtx), type:c.type});
 				}
 				ETry(e.rec(), newCatches);
 			case EFunction(name, func):

--- a/src/tink/macro/tools/ExprTools.hx
+++ b/src/tink/macro/tools/ExprTools.hx
@@ -113,7 +113,7 @@ class ExprTools {
 			case ECall(e, params): ECall(e.rec(), params.mapArray(f, ctx, pos));
 			case EIf(econd, eif, eelse): EIf(econd.rec(), eif.rec(), eelse.rec());
 			case ETernary(econd, eif, eelse): ETernary(econd.rec(), eif.rec(), eelse.rec());
-			case EBlock(exprs): EBlock(exprs.mapArray(f, ctx, pos));
+			case EBlock(exprs): EBlock(exprs.mapArray(f, ctx.copy(), pos));
 			case EArrayDecl(exprs): EArrayDecl(exprs.mapArray(f, ctx, pos));
 			case EIn(e1, e2): EIn(e1.rec(), e2.rec());
 			case EWhile(econd, e, normalWhile): EWhile(econd.rec(), e.rec(), normalWhile);


### PR DESCRIPTION
Hey Juraj,

I just added ExprTools.map to my fork of tink. It serves two purposes:
1. Traditional top-bottom traversal of expressions as opposed to the inside-out approach of crawl.
2. Preservation of a variable declaration context.

The idea is that it calls the mapping function with the current expression and context as arguments and then, if the function didn't change the expression, recursively maps all sub expressions. This approach made it really easy to implement the transform function of overload-operator:
https://github.com/Simn/overload-operator/blob/tink/src/deep/macro/math/OverloadOperator.hx#L83

It just handles the expression types it cares about and leaves the rest to ExprTools.map, which includes handling of the declared variables so expressions using them can be properly typed.

I know the function is way too big to actually reside in ExprTools, but I couldn't really decide where to externalise it to and just kept it there for now. I'm also not entirely happy with the signature because providing an array after the function looks pretty strange, so this could be changed.

Hope you find this useful.
