### PR TITLE
TypeTools.isDynamic()

### DIFF
--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -47,6 +47,12 @@ class TypeTools {
 		return 
 			ECheckType(ECheckType('null'.resolve(), toComplex(t)).at(pos), toComplex(of)).at(pos).typeof();
 	}
+	static public function isDynamic(t:Type) {
+		return switch(reduce(t)) {
+			case TDynamic(_): true;
+			default: false;
+		}
+	}
 	static public function toType(t:ComplexType, ?pos) {	
 		return [
 			'_'.define(t, pos),


### PR DESCRIPTION
Since t_dynamic.isSubTypeOf(anything) will report Success(anything), we need a function to check for the dynamic case.
