### PR TITLE
TypeTools.asTypePath - remove duplication when name == sub

### DIFF
--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -168,6 +168,7 @@ class TypeTools {
 		if (parts.length > 0 && parts[parts.length - 1].charCodeAt(0) < 0x5B) {
 			sub = name;
 			name = parts.pop();
+			if(sub == name) sub = null;
 		}
 		return {
 			name: name,


### PR DESCRIPTION
In some cases TypeTools.asTypePath returns a path where sub and name are the same. It is valid code, but adds a lot of clutter when printing out types.

It doesn't always happen, and is tricky to isolate, but I've seen this a lot when working when converting ClassFields to Fields, especially with types defined in StdTypes (e.g. String, Bool, Int, etc) 

which means that printing a field that should look like

```
function foo():String
```

looks like this instead 

```
function foo():String.String
```

This line patch sets sub to null if it is the same as name
