### PR TITLE
TypeTools.toComplex on private types requires pretty=false

### DIFF
--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -210,7 +210,7 @@ class TypeTools {
 						var t = t.get();
 						if(t.isPrivate)
 							return toComplex(type, false);
-						baseToComplex(t.get(), params);
+						baseToComplex(t, params);
 					case TInst(t, params):
 						var t = t.get();
 						if(t.isPrivate)

--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -207,9 +207,14 @@ class TypeTools {
 			if (pretty) {
 				switch (type) {
 					case TEnum(t, params):
+						var t = t.get();
+						if(t.isPrivate)
+							return toComplex(type, false);
 						baseToComplex(t.get(), params);
 					case TInst(t, params):
 						var t = t.get();
+						if(t.isPrivate)
+							return toComplex(type, false);
 						switch (t.kind) {
 							case KTypeParameter: asComplexType(t.name);
 							default: baseToComplex(t, params);
@@ -220,7 +225,10 @@ class TypeTools {
 							cArgs.push(toComplex(arg.t, true));
 						TFunction(cArgs, toComplex(ret, true));
 					case TType(t, params):
-						baseToComplex(t.get(), params);
+						var t = t.get();
+						if(t.isPrivate)
+							return toComplex(type, false);
+						baseToComplex(t, params);
 					case TLazy(f):
 						toComplex(f(), true);
 					//TODO: check TDynamic here


### PR DESCRIPTION
When converting a private Type to a ComplexType using toComplex(type, true), the 
resulting TPath is not valid and causes a compiler error (type not found)

The solution is to default back to non-pretty conversion if the BaseType  is private and allow 'tink.macro.tools.TypeTools.getType' to do it's magic.
### Example

I've run into this edge case with mocking classes using https://github.com/misprintt/mockatoo 

Mockatoo generates a Mock subclass using macros, but if a field's args or return type references a private type, the generated class does not have access to that type, causing the compilation error.

E.g. - On sys targets the Http class has a public method `customRequest()` containing an arg typed to the `private typedef AbstractSocket`

converting this arg's type to complex using TypeTools.toComplex generates a TypePath equivalent to: 

```
haxe.Http.AbstractSocket
```

Really it should be using the typepath's pack rather than module to generate a reference to the private type:

```
haxe._Http.AbstractSocket
```

But even isn't valid for the compiler, because the module haxe._Http doesn't exist

The patch checks if a type is private before calling baseToComplex()

> P.S. Sorry for reporting these edge cases, but on the whole tink_macros is an  amazing (
