### PR TITLE
Some Haxe 3 tink.macro compatability fixes

### DIFF
--- a/src/tink/collections/maps/AnyMap.hx
+++ b/src/tink/collections/maps/AnyMap.hx
@@ -14,18 +14,18 @@ private class StringRepMap<T> extends tink.collections.maps.base.StringIDMap < D
 		}
 	}
 #else
-	private typedef Ints<T> = IntHash<T>
+	private typedef Ints<T> = Map<Int,T>
 #end
 class AnyMap<V> implements Map < Dynamic, V >  implements Cls {
 	//TODO: consider using BoolMap as well
 	var ints:Ints<V>;
-	var strings:Hash<V>;
+	var strings:Map<StringV>;
 	var objs:ObjectMap<Dynamic, V>;
 	var misc:StringRepMap<V>;
 	var funcs:FunctionMap<Dynamic, V>;
 	public function new() {
 		this.ints = new Ints();
-		this.strings = new Hash();
+		this.strings = new Map();
 		this.objs = new ObjectMap();
 		this.misc = new StringRepMap();
 		this.funcs = new FunctionMap();

--- a/src/tink/collections/maps/IntMap.hx
+++ b/src/tink/collections/maps/IntMap.hx
@@ -10,9 +10,9 @@ import tink.lang.Cls;
 	}
 #else
 	class IntMap<T> implements Cls implements Map < Int, T > {
-		@:forward var h:IntHash<T>;
+		@:forward var h:Map<Int,T>;
 		public function new() {
-			this.h = new IntHash();
+			this.h = new Map();
 		}
 		public inline function set(key:Int, value:T):T {
 			h.set(key, value);

--- a/src/tink/collections/maps/ObjectMap.hx
+++ b/src/tink/collections/maps/ObjectMap.hx
@@ -34,7 +34,7 @@ package tink.collections.maps;
 	import tink.native.PHP;
 	class ObjectMap < K, V > extends tink.collections.maps.base.StringIDMap < K, V > {
 		override function transform(key:K):String untyped {
-			return PHP.objHash(key);
+			return PHP.objMap(key);
 		}
 	}
 #elseif (flash || js || neko || cpp)

--- a/src/tink/collections/maps/StringMap.hx
+++ b/src/tink/collections/maps/StringMap.hx
@@ -13,9 +13,9 @@ import tink.lang.Cls;
 	}
 #else
 	class StringMap<T> implements Map < String, T > implements Cls {
-		@:forward var h:Hash<T>;
+		@:forward var h:Map<StringT>;
 		public function new() {
-			this.h = new Hash();
+			this.h = new Map();
 		}
 		public inline function set(key:String, value:T) {
 			h.set(key, value);

--- a/src/tink/collections/maps/base/IntIDMap.hx
+++ b/src/tink/collections/maps/base/IntIDMap.hx
@@ -1,11 +1,11 @@
 package tink.collections.maps.base;
 
 class IntIDMap<K, V> implements tink.collections.maps.Map<K, V> {
-	var keyMap:IntHash<K>;
-	var valMap:IntHash<V>;
+	var keyMap:Map<Int,K>;
+	var valMap:Map<Int,V>;
 	public function new() {
-		this.keyMap = new IntHash();
-		this.valMap = new IntHash();
+		this.keyMap = new Map();
+		this.valMap = new Map();
 	}
 	function transform(key:K):Int {
 		return throw "base";

--- a/src/tink/collections/maps/base/StringIDMap.hx
+++ b/src/tink/collections/maps/base/StringIDMap.hx
@@ -1,11 +1,11 @@
 package tink.collections.maps.base;
 
 class StringIDMap<K, V> implements tink.collections.maps.Map<K, V> {
-	var keyMap:Hash<K>;
-	var valMap:Hash<V>;
+	var keyMap:Map<StringK>;
+	var valMap:Map<StringV>;
 	public function new() {
-		this.keyMap = new Hash();
-		this.valMap = new Hash();
+		this.keyMap = new Map();
+		this.valMap = new Map();
 	}
 	function transform(key:K):String {
 		return throw "base";

--- a/src/tink/lang/macros/PartialImpl.hx
+++ b/src/tink/lang/macros/PartialImpl.hx
@@ -49,7 +49,7 @@ class PartialImpl {
 			for (i in ctx.cls.interfaces)
 				for (f in TInst(i.t, i.params).getFields(true).sure()) {
 					var index = 0,
-						paramMap = new Hash();
+						paramMap = new Map();
 					for (p in i.t.get().params)
 						paramMap.set(p.name, i.params[index].toComplex(true));
 					if (!ctx.has(f.name)) {

--- a/src/tink/lang/macros/loops/FastLoops.hx
+++ b/src/tink/lang/macros/loops/FastLoops.hx
@@ -26,7 +26,7 @@ class FastLoops {
 		var fields = 
 			switch (fields) {
 				case TAnonymous(fields): 
-					var ret = new Hash();
+					var ret = new Map();
 					for (f in fields)
 						ret.set(f.name, f);
 					ret;
@@ -55,7 +55,7 @@ class FastLoops {
 					function iterator();
 				}
 			);
-			for (h in 'Hash,IntHash'.split(','))
+			for (h in 'Map,Map'.split(','))
 				addRules(h, 
 					macro: {
 						@:tink_for({ 
@@ -75,8 +75,8 @@ class FastLoops {
 		}
 		else if (Context.defined('neko')) {
 			var hashes = [
-				{ t: 'Hash', key: macro neko.NativeString.toString(a[i++]) },
-				{ t: 'IntHash', key: macro a[i++] },
+				{ t: 'Map', key: macro neko.NativeString.toString(a[i++]) },
+				{ t: 'Map', key: macro a[i++] },
 			];
 			for (h in hashes) {
 				var key = h.key;

--- a/src/tink/macro/build/Member.hx
+++ b/src/tink/macro/build/Member.hx
@@ -18,7 +18,7 @@ class Member {
 	public var doc : Null<String>;
 	public var kind : FieldType;
 	public var pos : Position;
-	var meta:Hash<Array<Meta>>;
+	var meta:Map<String,Array<Meta>>;
 	
 	public var isOverride:Bool;
 	public var isStatic:Bool;
@@ -29,7 +29,7 @@ class Member {
 	
 	public function new() {
 		this.isOverride = this.isStatic = false;
-		this.meta = new Hash();
+		this.meta = new Map();
 		this.excluded = false;
 	}
 	public inline function forceInline() {

--- a/src/tink/macro/build/MemberTransformer.hx
+++ b/src/tink/macro/build/MemberTransformer.hx
@@ -22,15 +22,15 @@ typedef ClassBuildContext = {
 }
 class MemberTransformer {
 	
-	var members:Hash<Member>;
-	var macros:Hash<Field>;
+	var members:Map<String,Member>;
+	var macros:Map<String,Field>;
 	var constructor:Null<Constructor>;
 	var localClass:ClassType;
-	var superFields:Hash<Bool>;
+	var superFields:Map<String,Bool>;
 	var verbose:Bool;
 	public function new(?verbose) { 
-		members = new Hash();
-		macros = new Hash();
+		members = new Map();
+		macros = new Map();
 		localClass = Context.getLocalClass().get();
 		this.verbose = verbose;
 	}
@@ -120,7 +120,7 @@ class MemberTransformer {
 	}
 	function hasSuperField(name:String) {
 		if (superFields == null) {
-			superFields = new Hash();
+			superFields = new Map();
 			var cl = localClass.superClass;
 			//var chain = [];
 			while (cl != null) {

--- a/src/tink/macro/tools/AST.hx
+++ b/src/tink/macro/tools/AST.hx
@@ -22,11 +22,11 @@ private class Builder {
 	var here:Expr;
 	var varName:String;
 	var posDecl:Expr;
-	var temps:Hash<String>;
+	var temps:Map<String,String>;
 	var subst:Bool;
 	static var NULL = EConst(CIdent('null'));
 	public function new(pos:Expr, ?noSubst = false) {
-		this.temps = new Hash();
+		this.temps = new Map();
 		this.subst = !noSubst;
 		var varName = String.tempName();
 		var posExpr = 

--- a/src/tink/macro/tools/Bouncer.hx
+++ b/src/tink/macro/tools/Bouncer.hx
@@ -10,8 +10,8 @@ class Bouncer {
 	//TODO: as is, a more less empty class is generated in the output. This is unneccessary.
 	#if macro
 		static var idCounter = 0;
-		static var bounceMap = new IntHash<Void->Expr>();
-		static var outerMap = new IntHash<Expr->Expr>();
+		static var bounceMap = new Map<Int,Void->Expr>();
+		static var outerMap = new Map<Int,Expr->Expr>();
 		static public function bounce(f:Void->Expr, ?pos) {
 			var id = idCounter++;
 			bounceMap.set(id, f);

--- a/src/tink/macro/tools/ExprTools.hx
+++ b/src/tink/macro/tools/ExprTools.hx
@@ -134,7 +134,7 @@ class ExprTools {
 			});
 	}
 	static public function partial<D>(c:ComplexType, data:D, ?pos) 
-		return ECheckType(macro null, c).at(pos).tag(data)
+		return ECheckType(macro null, c).at(pos).tag(data);
 	
 	static public function substitute(source:Expr, vars:Dynamic<Expr>, ?pos) 
 		return 
@@ -148,12 +148,12 @@ class ExprTools {
 								e;
 						default: e;
 					}
-			}, pos)
+			}, pos);
 	
 	static public inline function ifNull(e:Expr, fallback:Expr) 
 		return
-			if (e.getIdent().equals('null')) fallback
-			else e
+			if (e.getIdent().equals('null')) fallback;
+			else e;
 	
 	static public function substParams(source:Expr, subst:ParamSubst, ?pos):Expr 
 		return crawl(
@@ -168,10 +168,10 @@ class ExprTools {
 							else c;
 						default: c;
 					}
-			, pos)
+			, pos);
 	
 	static public function transform(source:Expr, transformer:Expr->Expr, ?pos):Expr 
-		return crawl(source, transformer, function (t) return t, pos)
+		return crawl(source, transformer, function (t) return t, pos);
 	
 	static function crawlArray(a:Array<Dynamic>, transformer:Expr->Expr, retyper:ComplexType->ComplexType, pos:Position):Array<Dynamic> {
 		var ret = [];
@@ -187,7 +187,7 @@ class ExprTools {
 				for (i in target)
 					t = i;
 				t;
-			}).finalize(target.pos).typeof()
+			}).finalize(target.pos).typeof();
 	
 	static function crawl(target:Dynamic, transformer:Expr->Expr, retyper:ComplexType->ComplexType, pos:Position):Dynamic {
 		return
@@ -364,7 +364,7 @@ class ExprTools {
 	}
 	
 	static public inline function iterate(target:Expr, body:Expr, ?loopVar:String = 'i', ?pos:Position) 
-		return EFor(EIn(loopVar.resolve(pos), target).at(pos), body).at(pos)
+		return EFor(EIn(loopVar.resolve(pos), target).at(pos), body).at(pos);
 	
 	static public function toFields(object:Dynamic<Expr>, ?pos:Position) {
 		var args = [];
@@ -379,55 +379,55 @@ class ExprTools {
 	}
 	
 	static public inline function reject(e:Expr, ?reason:String = 'cannot handle expression'):Dynamic 
-		return e.pos.error(reason)
+		return e.pos.error(reason);
 	
 	static public inline function toString(e:Expr):String 
-		return tink.macro.tools.Printer.printExpr('', e)
+		return tink.macro.tools.Printer.printExpr('', e);
 		
 	static public inline function at(e:ExprDef, ?pos:Position) 
 		return {
 			expr: e,
 			pos: pos.getPos()
-		}
+		};
 	
 	static public inline function instantiate(s:String, ?args:Array<Expr>, ?params:Array<TypeParam>, ?pos:Position) 
-		return s.asTypePath(params).instantiate(args, pos)
+		return s.asTypePath(params).instantiate(args, pos);
 	
 	static public inline function assign(target:Expr, value:Expr, ?op:Binop, ?pos:Position) 
-		return binOp(target, value, op == null ? OpAssign : OpAssignOp(op), pos)
+		return binOp(target, value, op == null ? OpAssign : OpAssignOp(op), pos);
 	
 	static public inline function define(name:String, ?init:Expr, ?typ:ComplexType, ?pos:Position) 
-		return at(EVars([ { name:name, type: typ, expr: init } ]), pos)
+		return at(EVars([ { name:name, type: typ, expr: init } ]), pos);
 	
 	static public inline function add(e1, e2, ?pos) 
-		return binOp(e1, e2, OpAdd, pos)
+		return binOp(e1, e2, OpAdd, pos);
 		
 	static public inline function unOp(e, op, ?postFix = false, ?pos) 
-		return EUnop(op, postFix, e).at(pos)
+		return EUnop(op, postFix, e).at(pos);
 	
 	static public inline function binOp(e1, e2, op, ?pos) 
-		return EBinop(op, e1, e2).at(pos)
+		return EBinop(op, e1, e2).at(pos);
 		
 	static public inline function field(e, field, ?pos) 
-		return EField(e, field).at(pos)
+		return EField(e, field).at(pos);
 		
 	static public inline function call(e, ?params, ?pos) 
-		return ECall(e, params == null ? [] : params).at(pos)
+		return ECall(e, params == null ? [] : params).at(pos);
 		
 	static public inline function toExpr(v:Dynamic, ?pos:Position) 
-		return Context.makeExpr(v, pos.getPos())
+		return Context.makeExpr(v, pos.getPos());
 		
 	static public inline function toArray(exprs:Iterable<Expr>, ?pos) 
-		return EArrayDecl(exprs.array()).at(pos)
+		return EArrayDecl(exprs.array()).at(pos);
 		
 	static public inline function toMBlock(exprs, ?pos) 
-		return EBlock(exprs).at(pos)
+		return EBlock(exprs).at(pos);
 		
 	static public inline function toBlock(exprs:Iterable<Expr>, ?pos) 
-		return toMBlock(Lambda.array(exprs), pos)
+		return toMBlock(Lambda.array(exprs), pos);
 		
 	static inline function isUC(s:String) 
-		return StringTools.fastCodeAt(s, 0) < 0x5B
+		return StringTools.fastCodeAt(s, 0) < 0x5B;
 		
 	static public function drill(parts:Array<String>, ?pos:Position, ?target:Expr) {
 		if (target == null) 
@@ -438,7 +438,7 @@ class ExprTools {
 	}
 	
 	static public inline function resolve(s:String, ?pos) 
-		return drill(s.split('.'), pos)
+		return drill(s.split('.'), pos);
 
 		
 	static var contexts = new List();
@@ -473,7 +473,7 @@ class ExprTools {
 			}				
 	}	
 	static public inline function cond(cond:ExprOf<Bool>, cons:Expr, ?alt:Expr, ?pos) 
-		return EIf(cond, cons, alt).at(pos)
+		return EIf(cond, cons, alt).at(pos);
 		
 	static public function isWildcard(e:Expr) 
 		return 
@@ -546,7 +546,7 @@ class ExprTools {
 	static inline var EMPTY_EXPRESSION = "expression expected";	
 	
 	static public function match(expr:Expr, pattern:Expr) 
-		return new Matcher().match(expr, pattern)
+		return new Matcher().match(expr, pattern);
 	
 }
 
@@ -554,8 +554,8 @@ private class Matcher {
 	var exprs:Dynamic<Expr>;
 	var strings:Dynamic<String>;
 	public function new() {
-		this.exprs = {}
-		this.strings = {}
+		this.exprs = {};
+		this.strings = {};
 	}
 	public function match(expr:Expr, pattern:Expr) {
 		return

--- a/src/tink/macro/tools/ExprTools.hx
+++ b/src/tink/macro/tools/ExprTools.hx
@@ -28,7 +28,7 @@ class ExprTools {
 		return ECheckType(e, c).at(e.pos).typeof().isSuccess();
 	}
 	static var annotCounter = 0;
-	static var annotations = new IntHash<Dynamic>();
+	static var annotations = new Map<Int,Dynamic>();
 	static public function tag<D>(e:Expr, data:D) {
 		annotations.set(annotCounter, data);
 		return [(annotCounter++).toExpr(e.pos), e].toBlock(e.pos);

--- a/src/tink/macro/tools/MetadataTools.hx
+++ b/src/tink/macro/tools/MetadataTools.hx
@@ -4,9 +4,9 @@ import haxe.macro.Expr;
 
 class MetadataTools 
 {	
-	static public function toHash(m:Metadata)
+	static public function toMap(m:Metadata)
 	{
-		var ret = new Hash<Array<Array<Expr>>>();
+		var ret = new Map<String,Array<Array<Expr>>>();
 		for (meta in m)
 		{
 			if (!ret.exists(meta.name))

--- a/src/tink/macro/tools/Printer.hx
+++ b/src/tink/macro/tools/Printer.hx
@@ -18,7 +18,7 @@ class Printer {
 			}			
 	}
 	static public function unoperator(u:Unop)
-		return unops[Type.enumIndex(u)]
+		return unops[Type.enumIndex(u)];
 	static public function binop(?indent:String = '', b:Binop, e1:Expr, e2:Expr):String {
 		function rec(e)
 			return printExpr(indent, e);		

--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -141,11 +141,11 @@ class TypeTools {
 			}
 	
 	static public function toString(t:ComplexType) 
-		return new Printer().printComplexType(t)
+		return new Printer().printComplexType(t);
 	
 	static public function isSubTypeOf(t:Type, of:Type, ?pos) 
 		return 
-			ECheckType(ECheckType('null'.resolve(), toComplex(t)).at(pos), toComplex(of)).at(pos).typeof()
+			ECheckType(ECheckType('null'.resolve(), toComplex(t)).at(pos), toComplex(of)).at(pos).typeof();
 	
 	static public function isDynamic(t:Type) 
 		return switch(reduce(t)) {
@@ -157,7 +157,7 @@ class TypeTools {
 		return [
 			'_'.define(t, pos),
 			'_'.resolve(pos)
-		].toBlock(pos).typeof()
+		].toBlock(pos).typeof();
 	
 	static public inline function instantiate(t:TypePath, ?args, ?pos) {
 		return ENew(t, args == null ? [] : args).at(pos);
@@ -176,13 +176,13 @@ class TypeTools {
 			pack: parts,
 			params: params == null ? [] : params,
 			sub: sub
-		}
+		};
 	}
 	static public inline function asComplexType(s:String, ?params) 
-		return TPath(asTypePath(s, params))
+		return TPath(asTypePath(s, params));
 	
 	static public inline function reduce(type:Type, ?once) 
-		return Context.follow(type, once)
+		return Context.follow(type, once);
 	
 	static public function isVar(field:ClassField) {
 		return switch (field.kind) {
@@ -202,7 +202,7 @@ class TypeTools {
 		return ret;
 	}
 	static function baseToComplex(t:BaseType, params:Array<Type>) 
-		return asComplexType(t.module + '.' + t.name, paramsToComplex(params))
+		return asComplexType(t.module + '.' + t.name, paramsToComplex(params));
 	
 	static public function toComplex(type:Type, ?pretty = false):ComplexType {
 		return 

--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -218,7 +218,11 @@ class TypeTools {
 						if(t.isPrivate)
 							return toComplex(type, false);
 						switch (t.kind) {
-							case KTypeParameter(_): asComplexType(t.name);
+							#if haxe3
+							case KTypeParameter(constraints): asComplexType(t.name, paramsToComplex(constraints));
+							#else
+							case KTypeParameter: asComplexType(t.name);
+							#end
 							default: baseToComplex(t, params);
 						}
 					case TFun(args, ret):
@@ -233,6 +237,15 @@ class TypeTools {
 						baseToComplex(t, params);
 					case TLazy(f):
 						toComplex(f(), true);
+					#if haxe3
+					case TAbstract(t, params):
+						var t = t.get();
+
+						if(t.isPrivate)
+							return toComplex(type, false); 
+
+						baseToComplex(t, params);
+					#end
 					//TODO: check TDynamic here
 					default: toComplex(type, false);
 				}

--- a/src/tink/macro/tools/TypeTools.hx
+++ b/src/tink/macro/tools/TypeTools.hx
@@ -14,7 +14,7 @@ using tink.macro.tools.FunctionTools;
 using tink.core.types.Outcome;
 
 class TypeTools {
-	static var types = new IntHash<Void->Type>();
+	static var types = new Map<Int,Void->Type>();
 	static var idCounter = 0;
 	macro static public function getType(id:Int):Type {
 		return types.get(id)();
@@ -42,7 +42,7 @@ class TypeTools {
 					throw 'not implemented';
 			}		
 	}
-	static function getDeclaredFields(t:ClassType, out:Array<ClassField>, marker:Hash<Bool>) {
+	static function getDeclaredFields(t:ClassType, out:Array<ClassField>, marker:Map<String,Bool>) {
 		for (field in t.fields.get()) 
 			if (!marker.exists(field.name)) {
 				marker.set(field.name, true);
@@ -56,7 +56,7 @@ class TypeTools {
 				getDeclaredFields(t.superClass.t.get(), out, marker);		
 	}
 	
-	static var fieldsCache = new Hash();
+	static var fieldsCache = new Map();
 	static public function getFields(t:Type, ?substituteParams = true) 
 		return
 			switch (reduce(t)) {
@@ -65,7 +65,7 @@ class TypeTools {
 						c = c.get();
 					if (!fieldsCache.exists(id)) {
 						var fields = [];
-						getDeclaredFields(c, fields, new Hash());
+						getDeclaredFields(c, fields, new Map());
 						fieldsCache.set(id, fields.asSuccess());
 					}
 					var ret = fieldsCache.get(id);

--- a/src/tink/native/PHP.hx
+++ b/src/tink/native/PHP.hx
@@ -9,10 +9,10 @@ class PHP {
 		var s = s.toExpr();
 		return macro untyped __php__($s);
 	}
-	static public function objHash(key:Dynamic):String {
+	static public function objMap(key:Dynamic):String {
 		if (embed('is_array($key)')) {
 			if (embed('is_callable($key)')) 
-				return objHash(key[0]) + key[1];
+				return objMap(key[0]) + key[1];
 			else 
 				throw 'cannot handle native PHP arrays yet';
 		}

--- a/src/tink/reactive/bindings/Binding.hx
+++ b/src/tink/reactive/bindings/Binding.hx
@@ -151,17 +151,17 @@ class Binding<T> implements Cls {
 }
 
 
-private typedef BindingMap = IntHash<Binding<Dynamic>>;
+private typedef BindingMap = Map<Int,Binding<Dynamic>>;
 
 #if !js
 @:generic 
 #end
 private class SingleSignaller<T, M:Map<T, BindingMap>> {
 	var keyMap:M;
-	var revisions:IntHash<Int>;
+	var revisions:Map<Int,Int>;
 	public function new(keyMap) {
 		this.keyMap = keyMap;
-		this.revisions = new IntHash();
+		this.revisions = new Map();
 	}
 	public inline function bind<A>(key:T, ?ret:A) {
 		watch(key, Binding.current());
@@ -171,14 +171,14 @@ private class SingleSignaller<T, M:Map<T, BindingMap>> {
 		if (watcher == null) return;
 		var bindings = keyMap.get(key);
 		if (bindings == null)
-			keyMap.set(key, bindings = new IntHash());
+			keyMap.set(key, bindings = new Map());
 		bindings.set(watcher.id, watcher);
 		revisions.set(watcher.id, watcher.revision);
 	}
 	public function fire<A>(key:T, ?ret:A) {
 		if (keyMap.exists(key)) {
 			var bindings = keyMap.get(key); 
-			keyMap.set(key, new IntHash());
+			keyMap.set(key, new Map());
 			for (b in bindings) {
 				if (b.revision == revisions.get(b.id))
 					b.invalidate();
@@ -201,13 +201,13 @@ private class UnknownSignaller {
 		if (watcher == null) return;
 		var bindings = keyMap.get(key);
 		if (bindings == null)
-			keyMap.set(key, bindings = new IntHash());
+			keyMap.set(key, bindings = new Map());
 		bindings.set(watcher.id, watcher);
 	}
 	public function fire<A>(key:Dynamic, ?ret:A) {
 		if (keyMap.exists(key)) {
 			var bindings = keyMap.get(key); 
-			keyMap.set(key, new IntHash());
+			keyMap.set(key, new Map());
 			for (b in bindings) b.invalidate();
 		}
 		return ret;

--- a/src/tink/reactive/bindings/macros/BindableProperties.hx
+++ b/src/tink/reactive/bindings/macros/BindableProperties.hx
@@ -47,8 +47,8 @@ class BindableProperties {
 				ctx.add(Member.plain('bindings', 'tink.reactive.bindings.Binding.Signaller'.asComplexType(), pos));
 				ctx.getCtor().init('bindings', pos, (macro new tink.reactive.bindings.Binding.Signaller()).finalize(pos), true);
 			}
-		var setters = new Hash(),
-			getters = new Hash();
+		var setters = new Map(),
+			getters = new Map();
 		for (member in ctx.members) {
 			switch (member.extractMeta(BINDABLE)) {
 				case Success(tag):

--- a/src/tink/reflect/Property.hx
+++ b/src/tink/reflect/Property.hx
@@ -50,7 +50,7 @@ import tink.devtools.Benchmark;
 			#elseif (neko || js || flash)
 				null;
 			#else
-				new Hash();
+				new Map();
 			#end
 		static inline function getForClass(cl:Class<Dynamic>) {
 			return 

--- a/src/tink/sql/macros/SqlBuilder.hx
+++ b/src/tink/sql/macros/SqlBuilder.hx
@@ -20,12 +20,12 @@ using Lambda;
 
 
 class SqlBuilder {
-	static var hx2sql:Hash<SqlBinop>; 
-	static var sql2string:Hash<String>;
+	static var hx2sql:Map<StringSqlBinop>; 
+	static var sql2string:Map<StringString>;
 	static function __init__() {
 		var m = Meta.getFields(SqlBinop);
-		hx2sql = new Hash();
-		sql2string = new Hash();
+		hx2sql = new Map();
+		sql2string = new Map();
 		for (f in Reflect.fields(m)) {
 			var a:Array<String> = Reflect.field(m, f).translate;
 			hx2sql.set(a[1], Enums.createEnum(SqlBinop, f));

--- a/src/tink/sql/macros/SqlData.hx
+++ b/src/tink/sql/macros/SqlData.hx
@@ -44,14 +44,14 @@ enum SqlEDef {
 	SqlBin(op:SqlBinop, e1:SqlExpr, e2:SqlExpr);
 } 
 class SqlDatabaseDesc {
-	var tables:Hash<SqlTableDesc>;
+	var tables:Map<StringSqlTableDesc>;
 	var type:Type;
 	function new(type:Type) {
 		this.type = type;
 	}
 	function init() {
 		if (tables == null) {
-			tables = new Hash();	
+			tables = new Map();	
 			for (f in type.getFields().sure()) 
 				if (f.type.getID() == 'tink.sql.Table') 
 					this.tables.set(f.name, SqlTableDesc.get(f.type, f.pos));
@@ -65,7 +65,7 @@ class SqlDatabaseDesc {
 		init();
 		return tables.get(name);
 	}
-	static var cache = new Hash<SqlDatabaseDesc>();	
+	static var cache = new Map<StringSqlDatabaseDesc>();	
 	static public function get(type:Type):SqlDatabaseDesc {
 		var key = Context.signature(type);
 		var ret = cache.get(key);
@@ -78,7 +78,7 @@ class SqlTableDesc {
 	public var name(default, null):String;
 	public var db(default, null):SqlDatabaseDesc;
 	
-	var fieldMap:Hash<ClassField>;
+	var fieldMap:Map<StringClassField>;
 	var fieldList:Array<ClassField>;
 	
 	public var type(default, null):Type;
@@ -90,7 +90,7 @@ class SqlTableDesc {
 		this.type = tb.type;
 		this.cType = tb.type.toComplex();
 		this.fieldList = tb.type.getFields().sure();
-		this.fieldMap = new Hash();
+		this.fieldMap = new Map();
 		
 		for (f in this.fieldList)
 			this.fieldMap.set(f.name, f);
@@ -106,7 +106,7 @@ class SqlTableDesc {
 	public inline function fields() {
 		return fieldList.iterator();
 	}
-	static var cache = new Hash<SqlTableDesc>();
+	static var cache = new Map<StringSqlTableDesc>();
 	static public function get(type:Type, pos:Position):SqlTableDesc {
 		return
 			switch (type) {
@@ -139,10 +139,10 @@ typedef SqlJoin = {
 class SqlContext {
 	public var first(default, null):SqlTableDesc;
 	var joins:Array<SqlJoin>;
-	var tableMap:Hash<SqlTableDesc>;
+	var tableMap:Map<StringSqlTableDesc>;
 	public function new(first:SqlTableDesc) {
 		this.first = first;
-		this.tableMap = new Hash();
+		this.tableMap = new Map();
 		this.tableMap.set(first.name, first);
 		this.joins = [];
 	}

--- a/src/tink/tween/Tween.hx
+++ b/src/tink/tween/Tween.hx
@@ -113,7 +113,7 @@ private class CuePoint<T> {
 }
 private typedef Cue<T> = Array<CuePoint<T>>;
 class TweenParams<T> implements Cls {
-	var propMap = new Hash<Bool>();
+	var propMap = new Map<StringBool>();
 	var properties = new Array<String>();
 	var atoms = new Array<TweenAtom<T>>();
 	var cue = new Cue<T>();

--- a/src/tink/tween/macros/PluginMap.hx
+++ b/src/tink/tween/macros/PluginMap.hx
@@ -11,7 +11,7 @@ import haxe.macro.Type;
 using tink.macro.tools.MacroTools;
 
 class PluginMap {
-	static var plugins = new Hash<PluginStack>();
+	static var plugins = new Map<StringPluginStack>();
 	macro static public function register():Array<Field> {
 		var cl = Context.getLocalClass().get();
 		if (cl.isInterface) return null;

--- a/src/tink/tween/plugins/HSVC.hx
+++ b/src/tink/tween/plugins/HSVC.hx
@@ -141,7 +141,7 @@ private class ColorMatrixHelper implements Cls {
 		if (saturation != 0) ret.adjustSaturation(saturation);
 		return ret.toArray();
 	}
-	static var archive = new Hash<ColorMatrixHelper>();
+	static var archive = new Map<StringColorMatrixHelper>();
 	public function release() {
 		if (--count == 0) {
 			map.delete(target);

--- a/src/tinx/node/io/InStream.hx
+++ b/src/tinx/node/io/InStream.hx
@@ -19,7 +19,7 @@ class InStream implements Cls {
 	@:signal var close = new VoidEmission(target, 'close');
 	@:signal var error:Exception = new Emission(target, 'error');
 	
-	var encoded:Hash<Signal<String>> = new Hash();
+	var encoded:Map<StringSignal<String>> = new Map();
 	
 	public function decode(?encoding = 'utf8'):Signal<String> {
 		if (!encoded.exists(encoding)) 

--- a/src/tinx/node/mongo/Internal.hx
+++ b/src/tinx/node/mongo/Internal.hx
@@ -15,12 +15,12 @@ extern class NativeDb {
 
 class DbBase implements Cls {
 	var native:Unsafe<NativeDb>;
-	var collections:Hash<Collection<Dynamic>>;
+	var collections:Map<StringCollection<Dynamic>>;
 	
 	public function new(?name = 'test', ?host = 'localhost', ?port = 27017, ?login: { user:String, password:String } ) {
 		var login = if (login == null) '' else (login.user +':' + login.password);
 		this.native = NativeDb.connect.bind('mongodb://$login@$host:$port/$name', { safe: true } ).future();
-		this.collections = new Hash();
+		this.collections = new Map();
 	}
 	public function close() 
 		native.handle(function(db) db.close())

--- a/src/tinx/node/mongo/lang/Path.hx
+++ b/src/tinx/node/mongo/lang/Path.hx
@@ -57,7 +57,7 @@ class StringAt {
 		this.s = s;
 		this.pos = pos;
 	}
-	public function getFrom<A>(h:Hash<A>, ?key:String = 'field')
+	public function getFrom<A>(h:Map<StringA>, ?key:String = 'field')
 		return 
 			if (h.exists(s)) h.get(s);
 			else pos.error('unknown $key $s')

--- a/src/tinx/node/mongo/lang/Projection.hx
+++ b/src/tinx/node/mongo/lang/Projection.hx
@@ -9,7 +9,7 @@ using tink.macro.tools.MacroTools;
 using tink.core.types.Outcome;
 using Lambda;
 
-private typedef Node = Hash<{ pos: Position, op:Op }>;
+private typedef Node = Map<String{ pos: Position, op:Op }>;
 
 private enum Op {
 	Plain;

--- a/src/tinx/node/mongo/lang/TypeInfo.hx
+++ b/src/tinx/node/mongo/lang/TypeInfo.hx
@@ -7,7 +7,7 @@ using tink.macro.tools.MacroTools;
 using tink.core.types.Outcome;
 
 class TypeInfo {
-	var fields:Hash<TypeInfo>;
+	var fields:Map<StringTypeInfo>;
 	public var t(default, null):Type;
 	var pos:Position;
 	var ct:ComplexType;
@@ -18,12 +18,12 @@ class TypeInfo {
 		function reject()
 			pos.error('type $t not supported by MongoDB');
 		
-		this.fields = new Hash();
+		this.fields = new Map();
 		
 		switch (t.reduce()) {
 			case TAnonymous(_):
 				this.fields = t.getFields().map(function (fields:Array<ClassField>) {
-					var ret = new Hash();
+					var ret = new Map();
 					for (f in fields)
 						ret.set(f.name, new TypeInfo(f.type, pos, true));
 					return ret;

--- a/src/tinx/node/mongo/lang/Update.hx
+++ b/src/tinx/node/mongo/lang/Update.hx
@@ -69,9 +69,9 @@ private class Parser {
 			}
 }
 private class Generator {
-	var ops:Hash<Hash<Expr>>;
+	var ops:Map<StringMap<StringExpr>>;
 	public function new(d:DocUpdate) {
-		ops = new Hash();
+		ops = new Map();
 		for (f in d)
 			switch (f.op) {
 				case Pop(shift):
@@ -96,7 +96,7 @@ private class Generator {
 	function fieldOp(opName:String, path:Path, expr) {
 		opName = opName.charAt(0).toLowerCase() + opName.substr(1);
 		if (!ops.exists(opName)) 
-			ops.set(opName, new Hash());
+			ops.set(opName, new Map());
 		var op = ops.get(opName);
 		var name = path.join('.');
 		if (op.exists(name))
@@ -109,7 +109,7 @@ private class Generator {
 			expr: expr
 		}
 		
-	function genOp(op:Hash<Expr>) 
+	function genOp(op:Map<StringExpr>) 
 		return 
 			EObjectDecl([
 				for (name in op.keys()) 


### PR DESCRIPTION
HI Juraj,

Hopefully these changes for Haxe3 are of use (i've been using this branch while migrating mockatoo)
- support for TAbstract in TypeTools.toComplex
- improved handling of KTypeParamater(?) in TypeTools.toComplex 
- remapping of Hash and IntHash to Map
- added back missing semi-colons that complier complained about
