### PR TITLE
Added sureOfFailure() for those of us who prefer failure to success

### DIFF
--- a/src/tink/core/types/Outcome.hx
+++ b/src/tink/core/types/Outcome.hx
@@ -22,6 +22,20 @@ class OutcomeTools {
 						throw failure;
 			}
 	}
+	static public function sureOfFailure < D, F > (outcome:Outcome < D, F > ):F {
+		return
+			switch (outcome) {
+				case Success(data): 
+					if (Std.is(data, ThrowableFailure)) {
+						var data:ThrowableFailure = cast data;//TODO: simplify this once haXe cast work correctly again
+						data.throwSelf();
+					}
+					else
+						throw data;
+				case Failure(failure): 
+					failure;
+			}
+	}
 	static public function toOption < D, F > (outcome:Outcome < D, F > ) {
 		return 
 			switch (outcome) {


### PR DESCRIPTION
Added sureOfFailure()

Basically to help with unit testing.  You can verify that an API fails as expected under certain conditions with a similarly short syntax to checking that it passes as expected.

Feel free to decline if it is against your tastes.  But I thought if it's useful to me it might be useful to others.
